### PR TITLE
Replace 'compile' with 'implementation'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,9 +40,9 @@ repositories {
 
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.github.wseemann:FFmpegMediaMetadataRetriever:1.0.14'
-    compile files('src/main/libs/jid3lib-0.5.4.jar')
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.github.wseemann:FFmpegMediaMetadataRetriever:1.0.14'
+    implementation files('src/main/libs/jid3lib-0.5.4.jar')
 }
   


### PR DESCRIPTION
'compile' is obsolete as of 2018 and has been replaced with 'implementation'