### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ MusicFiles returns an array of objects where you can loop, something like this.
 ]
 ```
 
-# RNAndroidStore
+# RNAndroidAudioStore
 
 This class is essentially an extended version of getMusicFiles but only works on android > 5.0.
 


### PR DESCRIPTION
replacing JAVA class name with JS named export ( people seem to import `RNAndroidStore` instead of `RNAndroidAudioStore` which leads to issues like [this](https://github.com/cinder92/react-native-get-music-files/issues/56#issuecomment-527615967) ).