### PR TITLE
Add nil checks for assetURL and other properties in TurboSongs module

### DIFF
--- a/ios/TurboSongs.mm
+++ b/ios/TurboSongs.mm
@@ -74,13 +74,23 @@ RCT_EXPORT_METHOD(getAll:(NSDictionary *)options
             
             MPMediaItemArtwork *artwork = [song valueForProperty: MPMediaItemPropertyArtwork];
 
-            [songDictionary setValue:[NSString stringWithString:assetURL.absoluteString] forKey:@"url"];
-            [songDictionary setValue:[NSString stringWithString:title] forKey:@"title"];
-            [songDictionary setValue:[NSString stringWithString:albumTitle] forKey:@"album"];
-            [songDictionary setValue:[NSString stringWithString:albumArtist] forKey:@"artist"];
+            if (assetURL != nil && assetURL.absoluteString != nil) {
+                [songDictionary setValue:[NSString stringWithString:assetURL.absoluteString] forKey:@"url"];
+            }
+            if (title != nil) {
+                [songDictionary setValue:[NSString stringWithString:title] forKey:@"title"];
+            }
+            if (albumTitle != nil) {
+                [songDictionary setValue:[NSString stringWithString:albumTitle] forKey:@"album"];
+            }
+            if (albumArtist != nil) {
+                [songDictionary setValue:[NSString stringWithString:albumArtist] forKey:@"artist"];
+            }
             [songDictionary setValue:[NSNumber numberWithInt:durationInt * 1000] forKey:@"duration"];
-            [songDictionary setValue:[NSString stringWithString:genre] forKey:@"genre"];
-            
+            if (genre != nil) {
+                [songDictionary setValue:[NSString stringWithString:genre] forKey:@"genre"];
+            }
+
             if (artwork != nil) {
                 UIImage *image = [artwork imageWithSize:CGSizeMake(coverQty, coverQty)];
                 // http://www.12qw.ch/2014/12/tooltip-decoding-base64-images-with-chrome-data-url/
@@ -173,12 +183,20 @@ RCT_EXPORT_METHOD(getAlbums:(NSDictionary *)options
             NSString *albumArtist = [album valueForProperty: MPMediaItemPropertyAlbumArtist]; //
             NSString *numberOfSongs = [album valueForProperty: MPMediaItemPropertyAlbumTrackCount]; //
             MPMediaItemArtwork *artwork = [album valueForProperty: MPMediaItemPropertyArtwork];
-       
-            [songDictionary setValue:[NSString stringWithString:assetURL.absoluteString] forKey:@"url"];
-            [songDictionary setValue:[NSString stringWithString:albumTitle] forKey:@"album"];
-            [songDictionary setValue:[NSString stringWithString:albumArtist] forKey:@"artist"];
-            [songDictionary setValue:[NSString stringWithString:numberOfSongs] forKey:@"numberOfSongs"];
-            
+
+            if (assetURL != nil && assetURL.absoluteString != nil) {
+                [songDictionary setValue:[NSString stringWithString:assetURL.absoluteString] forKey:@"url"];
+            }
+            if (albumTitle != nil) {
+                [songDictionary setValue:[NSString stringWithString:albumTitle] forKey:@"album"];
+            }
+            if (albumArtist != nil) {
+                [songDictionary setValue:[NSString stringWithString:albumArtist] forKey:@"artist"];
+            }
+            if (numberOfSongs != nil) {
+                [songDictionary setValue:[NSString stringWithString:numberOfSongs] forKey:@"numberOfSongs"];
+            }
+
             if (artwork != nil) {
                 UIImage *image = [artwork imageWithSize:CGSizeMake(coverQty, coverQty)];
                 // http://www.12qw.ch/2014/12/tooltip-decoding-base64-images-with-chrome-data-url/
@@ -271,13 +289,24 @@ RCT_EXPORT_METHOD(search:(NSDictionary *)options
             
             MPMediaItemArtwork *artwork = [song valueForProperty: MPMediaItemPropertyArtwork];
 
+            if (assetURL != nil && assetURL.absoluteString != nil) {
+                [songDictionary setValue:[NSString stringWithString:assetURL.absoluteString] forKey:@"url"];
+            }
             [songDictionary setValue:[NSString stringWithString:assetURL.absoluteString] forKey:@"url"];
-            [songDictionary setValue:[NSString stringWithString:title] forKey:@"title"];
-            [songDictionary setValue:[NSString stringWithString:albumTitle] forKey:@"album"];
-            [songDictionary setValue:[NSString stringWithString:albumArtist] forKey:@"artist"];
+            if (title != nil) {
+                [songDictionary setValue:[NSString stringWithString:title] forKey:@"title"];
+            }
+            if (albumTitle != nil) {
+                [songDictionary setValue:[NSString stringWithString:albumTitle] forKey:@"album"];
+            }
+            if (albumArtist != nil) {
+                [songDictionary setValue:[NSString stringWithString:albumArtist] forKey:@"artist"];
+            }
             [songDictionary setValue:[NSNumber numberWithInt:durationInt * 1000] forKey:@"duration"];
-            [songDictionary setValue:[NSString stringWithString:genre] forKey:@"genre"];
-            
+            if (genre != nil) {
+                [songDictionary setValue:[NSString stringWithString:genre] forKey:@"genre"];
+            }
+
             if (artwork != nil) {
                 UIImage *image = [artwork imageWithSize:CGSizeMake(coverQty, coverQty)];
                 // http://www.12qw.ch/2014/12/tooltip-decoding-base64-images-with-chrome-data-url/


### PR DESCRIPTION
This commit introduces essential nil checks across the TurboSongs module to ensure stability and error handling for properties that might not always be present, such as the assetURL, title, albumTitle, and more. Notably, this update addresses a common scenario with Apple Music, where downloaded songs for offline use do not have an assetURL. By adding these checks, the module now safely handles such cases, preventing potential crashes and improving the user experience when working with local and downloaded media items. This enhancement is crucial for developers integrating with the Apple Music library, ensuring that their applications can gracefully handle a variety of media item states.

To reproduce the issue, follow these steps: Navigate to Apple Music, select a song, add it to your library, then select the song from within your library and download it for offline use. In this scenario, the song's `assetURL` may be absent, leading to the issue this pull request addresses.
